### PR TITLE
Fix syntax error

### DIFF
--- a/enhanced-security-script.sh
+++ b/enhanced-security-script.sh
@@ -209,7 +209,7 @@ restore_backup() {
     # Verify archive checksum
     if ! sha256sum -c "${backup_path}.tar.gz.sha256"; then
         handle_error "Backup archive integrity check failed" 13
-    }
+    fi
     
     # Extract archive
     sudo tar -xzf "${backup_path}.tar.gz" -C / || handle_error "Failed to extract backup archive" 14
@@ -1054,6 +1054,9 @@ main() {
     
     # Parse command line arguments and set initial configuration
     parse_arguments "$@"
+
+    # Create backup directory with secure permissions
+    sudo install -d -m 0700 "$BACKUP_DIR" || handle_error "Failed to create backup directory" 10
     
     # Validate environment and requirements
     check_requirements


### PR DESCRIPTION
I have fix the syntax error.
} to fi to close a condition.

And create the directory to allow to create the error report if the dependency doesn't exist.